### PR TITLE
BUGFIX: Keep flow exit code intact

### DIFF
--- a/flow.plugin.zsh
+++ b/flow.plugin.zsh
@@ -98,7 +98,9 @@ flow() {
     builtin cd ..
   done
   ./flow $@
+  local flowExitCode=$?
   builtin cd $startDirectory
+  return $flowExitCode
 }
 
 ######################################


### PR DESCRIPTION
When using `flow` (as opposed to `./flow`) the exit code is always 0, regardless
of what Flow actually returns. This fixes this behaviour.