### PR TITLE
use dynamically initialized var for plugin dir

### DIFF
--- a/flow.plugin.zsh
+++ b/flow.plugin.zsh
@@ -1,6 +1,7 @@
 #####################################
 # Section: Flow Autocompletion Helper
 #####################################
+ZSH_FLOW_PLUGIN_DIR=${0:a:h}
 
 #
 # the ZSH autocompletion function for Flow (main entry point)
@@ -33,7 +34,7 @@ compdef _flow flow
 _flow_main_commands() {
   if [ ! -f Data/Temporary/Development/.flow-autocompletion-maincommands ]; then
     mkdir -p Data/Temporary/Development/
-    ./flow help | grep  "^[* ][ ]" | php $ZSH_CUSTOM/plugins/flow/helper-postprocess-cmdlist.php > Data/Temporary/Development/.flow-autocompletion-maincommands
+    ./flow help | grep  "^[* ][ ]" | php $ZSH_FLOW_PLUGIN_DIR/helper-postprocess-cmdlist.php > Data/Temporary/Development/.flow-autocompletion-maincommands
   fi
 
   # fills up cmdlist variable
@@ -245,7 +246,7 @@ f-set-distribution() {
   done
   echo -n "Your Choice: "
   read choice
-  echo $flow_distribution_paths[$choice] > $ZSH_CUSTOM/plugins/flow/f-environment-choice.txt
+  echo $flow_distribution_paths[$choice] > $ZSH_FLOW_PLUGIN_DIR/f-environment-choice.txt
 
   # Now, after updating f-environment-choice.txt, send USR2 signal to
   # all running ZSH instances such that they reload
@@ -267,11 +268,11 @@ TRAPUSR2() {
 # Internal helper to update cdpath
 #
 _f-update-distribution-path() {
-  if [ -f $ZSH_CUSTOM/plugins/flow/f-environment-choice.txt ]; then
+  if [ -f $ZSH_FLOW_PLUGIN_DIR/f-environment-choice.txt ]; then
   else
     return
   fi
-  local fBasePath=`cat $ZSH_CUSTOM/plugins/flow/f-environment-choice.txt`
+  local fBasePath=`cat $ZSH_FLOW_PLUGIN_DIR/f-environment-choice.txt`
 
   # we need to add "." to the current CDPath, else Composer etc breaks...
   cdpath=(. $fBasePath/Packages/Framework/ $fBasePath/Packages/Neos/ $fBasePath/Packages/Application/ $fBasePath/Packages/Sites/)
@@ -299,6 +300,6 @@ flogs() {
   local flowBaseDir=`pwd`
   builtin cd $startDirectory
 
-  flow_path="$flowBaseDir" osascript $ZSH_CUSTOM/plugins/flow/flowlog.applescript
+  flow_path="$flowBaseDir" osascript $ZSH_FLOW_PLUGIN_DIR/flowlog.applescript
 
 }


### PR DESCRIPTION
Using the specific path $ZSH_CUSTOM/plugins/flow does break compatiblity with https://getantibody.github.io/.
This pluginmanager creates a folder underneath ~/Library in the form ~/Library/Caches/antibody/https-COLON--SLASH--SLASH-github.com-SLASH-sandstorm-SLASH-oh-my-zsh-flow-plugin.

The Failing behavour looked exactly like #10 and #16 
```
flow (eval):1: command not found: Could
```

To address this issue i created a global var which is initialized on plugin load with the relative path to the plugin file ($0).
I hope this also fixes the other issues
